### PR TITLE
Issue-411 (kamon) - fix pointcut to use the new akka OptionVal

### DIFF
--- a/kamon-akka-remote-2.4.x/src/main/scala/kamon/akka/KamonOptionVal.scala
+++ b/kamon-akka-remote-2.4.x/src/main/scala/kamon/akka/KamonOptionVal.scala
@@ -1,0 +1,10 @@
+package akka
+
+import akka.util.{ OptionVal ⇒ AkkaOptionVal }
+
+/**
+ * The sole purpose of this object is to provide access to the otherwise internal class [[akka.util.OptionVal]].
+ */
+object KamonOptionVal {
+  type OptionVal[+T >: Null] = AkkaOptionVal[T]
+}

--- a/kamon-akka-remote-2.4.x/src/test/scala/kamon/testkit/BaseKamonSpec.scala
+++ b/kamon-akka-remote-2.4.x/src/test/scala/kamon/testkit/BaseKamonSpec.scala
@@ -62,5 +62,5 @@ abstract class BaseKamonSpec(actorSystemName: String) extends TestKitBase with W
     subscriptions.tell(SubscriptionsDispatcher.Tick)
   }
 
-  override protected def afterAll(): Unit = system.shutdown()
+  override protected def afterAll(): Unit = system.terminate()
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val aspectjVersion    = "1.8.9"
 
   val akka23Version       = "2.3.13"
-  val akka24Version       = "2.4.10" //TODO kamon does not propagate trace context with akka 2.4.11+
+  val akka24Version       = "2.4.16"
 
   val aspectJ             = "org.aspectj"                 %   "aspectjweaver"         % aspectjVersion
 


### PR DESCRIPTION
Fix https://github.com/kamon-io/Kamon/issues/411

Not sure if this fix/hack is appropriate, but I managed to propagate the trace context across 2 actors in different cluster nodes in Akka 2.4.16.